### PR TITLE
Fix json.hpp not found

### DIFF
--- a/src/lib/camera_node.cpp
+++ b/src/lib/camera_node.cpp
@@ -24,7 +24,7 @@
 #include <ifm3d_ros2/buffer_id_utils.hpp>
 #include <ifm3d_ros2/qos.hpp>
 
-#include <ifm3d/contrib/nlohmann/json.hpp>
+#include <ifm3d/device/json.hpp>
 
 using json = ifm3d::json;
 using namespace std::chrono_literals;


### PR DESCRIPTION
Suggested fix for missing header file:

`ifm3d-ros2/src/lib/camera_node.cpp:27:10: fatal error: ifm3d/contrib/nlohmann/json.hpp: No such file or directory`