### PR TITLE
Resolve  path in launchfile, use placeholder for config_file value in yaml files

### DIFF
--- a/config/camera_default_parameters.yaml
+++ b/config/camera_default_parameters.yaml
@@ -3,6 +3,7 @@
 
 /ifm3d/camera:
   ros__parameters:
+    config_file: "/this/path/will/be/overridden/from/the/lauchfile/because/yaml/files/cant/resolve/find-pkg-share/command"
     buffer_id_list:
       - CONFIDENCE_IMAGE
       - EXTRINSIC_CALIB

--- a/config/examples/o3r_2d.yaml
+++ b/config/examples/o3r_2d.yaml
@@ -3,6 +3,7 @@
 
 /ifm3d/camera_2d:
   ros__parameters:
+    config_file: "/this/path/will/be/overridden/from/the/lauchfile/because/yaml/files/cant/resolve/find-pkg-share/command"
     buffer_id_list:
       - JPEG_IMAGE
       - RGB_INFO

--- a/config/examples/o3r_3d.yaml
+++ b/config/examples/o3r_3d.yaml
@@ -3,6 +3,7 @@
 
 /ifm3d/camera_3d:
   ros__parameters:
+    config_file: "/this/path/will/be/overridden/from/the/lauchfile/because/yaml/files/cant/resolve/find-pkg-share/command"
     buffer_id_list:
       - CONFIDENCE_IMAGE
       - EXTRINSIC_CALIB

--- a/config/ods_default_parameters.yaml
+++ b/config/ods_default_parameters.yaml
@@ -6,9 +6,10 @@
 
 /ifm3d/ods:
   ros__parameters:
-    config_file: "config/examples/o3r_ods.json"
+    config_file: "/this/path/will/be/overridden/from/the/lauchfile/because/yaml/files/cant/resolve/find-pkg-share/command"
     ip: 192.168.0.69
     pcic_port: 51010
+    xmlrpc_port: 80
     ods:
       frame_id: "ifm_base_link"
       publish_occupancy_grid: true

--- a/launch/camera.launch.py
+++ b/launch/camera.launch.py
@@ -4,7 +4,7 @@
 #
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, EmitEvent, RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, EmitEvent, RegisterEventHandler, LogInfo
 from launch.conditions import IfCondition
 from launch.events import matches_action
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
@@ -70,10 +70,52 @@ def generate_launch_description():
             description="YAML file with the camera configuration.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "o3r_device_config_file_name",
+            default_value="deviceConfigO3R.o3rcfg",
+            description="IFM VPU device configuration file (can be downloaded via ifmVisionAssistant or `o3r.get()`).",
+        )
+    )
 
     # ------------------------------------------------------------
     # Nodes, using substitutions to fill in arguments
     # ------------------------------------------------------------
+
+    # Resolve the YAML parameter file path:
+    param_file_path = PathJoinSubstitution([
+        FindPackageShare(LaunchConfiguration("parameter_file_package")),
+        LaunchConfiguration("parameter_file_directory"),
+        LaunchConfiguration("parameter_file_name"),
+    ])
+    log_param_file_path = LogInfo(
+        msg=[
+            "Parameter file for camera_namespace=",
+            LaunchConfiguration('camera_namespace'),
+            ", camera_name=",
+            LaunchConfiguration('camera_name'),
+            ": ",
+            param_file_path
+        ]
+    )
+
+    # Resolve the O3R .o3rcfg file path:
+    o3r_device_cfg_path = PathJoinSubstitution([
+        FindPackageShare(LaunchConfiguration("parameter_file_package")),
+        LaunchConfiguration("parameter_file_directory"),
+        LaunchConfiguration("o3r_device_config_file_name"),
+    ])
+    log_o3r_device_cfg_file_path = LogInfo(
+        msg=[
+            "O3R device config file for camera_namespace=",
+            LaunchConfiguration('camera_namespace'),
+            ", camera_name=",
+            LaunchConfiguration('camera_name'),
+            ": ",
+            o3r_device_cfg_path
+        ]
+    )
+
     camera_node = LifecycleNode(
         package="ifm3d_ros2",
         executable="camera_standalone",
@@ -81,13 +123,9 @@ def generate_launch_description():
         name=LaunchConfiguration("camera_name"),
         output='screen',
         parameters=[
-            PathJoinSubstitution(
-                [
-                    FindPackageShare(LaunchConfiguration("parameter_file_package")),
-                    LaunchConfiguration("parameter_file_directory"),
-                    LaunchConfiguration("parameter_file_name"),
-                ]
-            )
+            param_file_path,
+            # override `config_file` parameter here because we can't resolve a path dynamically in the YAML parameter file
+            {"config_file": o3r_device_cfg_path},
         ],
         arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
         log_cmd=True,
@@ -144,5 +182,7 @@ def generate_launch_description():
     ld.add_action(rviz_node)
     ld.add_action(configure_camera)
     ld.add_action(activate_camera)
+    ld.add_action(log_param_file_path)
+    ld.add_action(log_o3r_device_cfg_file_path)
 
     return ld

--- a/src/lib/camera_node.cpp
+++ b/src/lib/camera_node.cpp
@@ -98,14 +98,20 @@ TC_RETVAL CameraNode::on_configure(const rclcpp_lifecycle::State& prev_state)
 
   if (this->config_file_!=""){
     std::ifstream file(this->config_file_);
-    if (!file.is_open()) {
-      throw std::runtime_error("Could not open config file: " + this->config_file_);
+
+    if (!std::filesystem::is_regular_file(this->config_file_)) {
+      RCLCPP_WARN(this->logger_, "Config file path exists but is not a regular file: %s", this->config_file_.c_str());
     }
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    RCLCPP_DEBUG(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
-    ifm3d::json config_json = json::parse(buffer.str()) ;
-    this->o3r_->Set(config_json);
+    else {
+      if (!file.is_open()) {
+        throw std::runtime_error("Could not open config file: " + this->config_file_);
+      }
+      std::stringstream buffer;
+      buffer << file.rdbuf();
+      RCLCPP_DEBUG(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
+      ifm3d::json config_json = json::parse(buffer.str()) ;
+      this->o3r_->Set(config_json);
+    }
   }
 
   // Get all the necessary info for the port.

--- a/src/lib/camera_node.cpp
+++ b/src/lib/camera_node.cpp
@@ -103,7 +103,7 @@ TC_RETVAL CameraNode::on_configure(const rclcpp_lifecycle::State& prev_state)
     }
     std::stringstream buffer;
     buffer << file.rdbuf();
-    RCLCPP_INFO(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
+    RCLCPP_DEBUG(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
     ifm3d::json config_json = json::parse(buffer.str()) ;
     this->o3r_->Set(config_json);
   }

--- a/src/lib/ods_node.cpp
+++ b/src/lib/ods_node.cpp
@@ -321,6 +321,11 @@ void OdsNode::init_params()  // TODO cleanup params
    *   - Define Descriptor
    *   - Declare Parameter
    */
+  rcl_interfaces::msg::ParameterDescriptor config_descriptor;
+  config_descriptor.name = "config_file";
+  config_descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  config_descriptor.description = "Configuration file, in JSON format.";
+  this->declare_parameter("config_file", "", config_descriptor);
 
   rcl_interfaces::msg::ParameterDescriptor ip_descriptor;
   ip_descriptor.name = "ip";

--- a/src/lib/ods_node.cpp
+++ b/src/lib/ods_node.cpp
@@ -102,15 +102,20 @@ TC_RETVAL OdsNode::on_configure(const rclcpp_lifecycle::State& prev_state)
   // If a configuration file is provided, configure the device.
   if (this->config_file_!=""){
     std::ifstream file(this->config_file_);
-    if (!file.is_open()) {
-      throw std::runtime_error("Could not open config file: " + this->config_file_);
+
+    if (!std::filesystem::is_regular_file(this->config_file_)) {
+      RCLCPP_WARN(this->logger_, "Config file path exists but is not a regular file: %s", this->config_file_.c_str());
     }
-    std::stringstream buffer;
-    buffer << file.rdbuf();
-    RCLCPP_DEBUG(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
-    ifm3d::json config_json = json::parse(buffer.str()) ;
-    this->o3r_->Set(config_json);
-  }
+    else {
+      if (!file.is_open()) {
+        throw std::runtime_error("Could not open config file: " + this->config_file_);
+      }
+      std::stringstream buffer;
+      buffer << file.rdbuf();
+      RCLCPP_DEBUG(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
+      ifm3d::json config_json = json::parse(buffer.str()) ;
+      this->o3r_->Set(config_json);
+    }
 
   // Get all the necessary info for the port.
   for (auto port : this->o3r_->Ports())

--- a/src/lib/ods_node.cpp
+++ b/src/lib/ods_node.cpp
@@ -107,7 +107,7 @@ TC_RETVAL OdsNode::on_configure(const rclcpp_lifecycle::State& prev_state)
     }
     std::stringstream buffer;
     buffer << file.rdbuf();
-    RCLCPP_INFO(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
+    RCLCPP_DEBUG(this->logger_, "Setting configuration: %s",  buffer.str().c_str());
     ifm3d::json config_json = json::parse(buffer.str()) ;
     this->o3r_->Set(config_json);
   }


### PR DESCRIPTION
This is slightly related to Issue https://github.com/ifm/ifm3d-ros2/issues/25 but the main change is the following: 

### Problem: 
- The yaml config files (e.g. `/config/ods_default_parameters.yaml`) contain a parameter `config_file`, whose value is a path to the device configuration file (`.json` or `.o3rcfg`). 
- This path has to be an absolute or relative path, both can easily lead to problems. 
  - When using an absolute path the configuration will not work if for example the project is moved or someone clones the project in a different location. 
  - When using a relative path, this is relative to the current working directory at the time of launching the node. So it might work if I run `ros2 launch ifm3d_ros2 camera.launch.py` from my main `~/projects/ifm3d_ros2_workspace/` folder but not if I run it from `~/projects/ifm3d_ros2_workspace/src/` folder or any other location. 
- Directives like `find-pkg-share` don´t work in ros2 yaml files, so we have no direct way to dynamically resolve a path in the yaml file (`"$(find-pkg-share ifm3d_ros2)/config/my_device_config.o3rcfg"`). 

### Solution: 
- Use a placeholder as a value for the `config_file` parameter in the yaml files. 
- Resolve the path for the config_file one step earlier in the launchfiles (`camera.launch.py` and `ods.launch.py`)
- Overwrite the `config_file` parameter value with the resolved path

### Additional Changes: 
- add missing `declare_parameter` for the `config_file` parameter in `ods_node.cpp`
- log the yaml configuration filepath and the resolved `config_file` value in the launchfiles. 
- Change `RCLCPP_INFO` to `RCLCPP_DEBUG` for logging the configuration contents in `camera_node.cpp` and `ods_node.cpp` because this produces a lot of output. 
