### PR TITLE
Added parameter to choose time source for messages

### DIFF
--- a/config/camera_default_parameters.yaml
+++ b/config/camera_default_parameters.yaml
@@ -24,3 +24,4 @@
       publish_mounting_to_optical: true
     use_sim_time: false
     xmlrpc_port: 80
+    use_timestamp_from_device: true

--- a/config/ods_default_parameters.yaml
+++ b/config/ods_default_parameters.yaml
@@ -13,3 +13,4 @@
       frame_id: "ifm_base_link"
       publish_occupancy_grid: true
       publish_costmap: false
+    use_timestamp_from_device: true

--- a/doc/camera_node/parameters.md
+++ b/doc/camera_node/parameters.md
@@ -13,6 +13,7 @@
 | `~/tf.publish_base_to_mounting`    | bool         | true                                                                                                                                                                                    | Whether the transform from the ifm base link to the camera mounting point should be published.   |
 | `~/tf.publish_mounting_to_optical` | bool         | true                                                                                                                                                                                    | Whether the transform from the cameras mounting point to the optical center should be published. |
 | `~/xmlrpc_port`                    | uint         | 50010                                                                                                                                                                                   | TCP port the on-camera xmlrpc server is listening on.                                            |
+| `~/use_timestamp_from_device       | bool         | true                                                                                                                                                                                    | Uses timestamp from VPU for messages if true; uses ROS time if false;                            |
 
 ## Details on the published transforms
 

--- a/include/ifm3d_ros2/camera_node.hpp
+++ b/include/ifm3d_ros2/camera_node.hpp
@@ -202,6 +202,7 @@ private:
   std::string ip_{};
   std::uint16_t pcic_port_{};
   std::uint16_t xmlrpc_port_{};
+  bool use_timestamp_from_device_{};
 
   // For backward compatibility, we get the port name
   // from the provided pcic_port.

--- a/include/ifm3d_ros2/ods_module.hpp
+++ b/include/ifm3d_ros2/ods_module.hpp
@@ -33,7 +33,8 @@ class OdsModule : public FunctionModule, public std::enable_shared_from_this<Ods
   using ZonesPublisher = std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<ZonesMsg>>;
 
 public:
-  OdsModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr);
+  OdsModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr,
+            bool use_timestamp_from_device = true);
   // Main functions that take care of deserializing
   // and publishing the ODS data
   void handle_frame(ifm3d::Frame::Ptr frame);
@@ -68,6 +69,7 @@ private:
   std::string frame_id_;
   bool publish_occupancy_grid_;
   bool publish_costmap_;
+  bool use_timestamp_from_device_;
   rcl_interfaces::msg::ParameterDescriptor frame_id_descriptor_;
   rcl_interfaces::msg::ParameterDescriptor publish_occupancy_grid_descriptor_;
   rcl_interfaces::msg::ParameterDescriptor publish_costmap_descriptor_;

--- a/include/ifm3d_ros2/ods_node.hpp
+++ b/include/ifm3d_ros2/ods_node.hpp
@@ -184,6 +184,7 @@ private:
   std::string ip_{};
   std::uint16_t pcic_port_{};
   std::uint16_t xmlrpc_port_{};
+  bool use_timestamp_from_device_{};
 
   ifm3d::PortInfo port_info_{};
 

--- a/include/ifm3d_ros2/rgb_module.hpp
+++ b/include/ifm3d_ros2/rgb_module.hpp
@@ -36,7 +36,7 @@ class RgbModule : public FunctionModule, public std::enable_shared_from_this<Rgb
 {
 public:
   RgbModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr, ifm3d::O3R::Ptr o3r_ptr,
-            std::string port, uint32_t width, uint32_t height);
+            std::string port, uint32_t width, uint32_t height, bool use_timestamp_from_device = true);
   void handle_frame(ifm3d::Frame::Ptr frame);
 
   const std::string get_name()
@@ -70,6 +70,8 @@ private:
   // Values read from incoming image buffers
   uint32_t width_;
   uint32_t height_;
+
+  bool use_timestamp_from_device_;
 
   // Boolean to track first time publishing, so that we only
   // publish the static transforms once

--- a/include/ifm3d_ros2/tof_module.hpp
+++ b/include/ifm3d_ros2/tof_module.hpp
@@ -51,7 +51,7 @@ class TofModule : public FunctionModule, public std::enable_shared_from_this<Tof
 {
 public:
   TofModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr, ifm3d::O3R::Ptr o3r_ptr,
-            std::string port, uint32_t width, uint32_t height);
+            std::string port, uint32_t width, uint32_t height, bool use_timestamp_from_device = true);
   /**
    * @brief Unpacks data from the received frame, and publish
    * the topics corresponding to the requested image buffers.
@@ -92,6 +92,8 @@ private:
   // Values read from incoming image buffers
   uint32_t width_;
   uint32_t height_;
+
+  bool use_timestamp_from_device_;
 
   // Value used to only publish the static transform once
   bool first_;

--- a/src/lib/camera_node.cpp
+++ b/src/lib/camera_node.cpp
@@ -132,7 +132,8 @@ TC_RETVAL CameraNode::on_configure(const rclcpp_lifecycle::State& prev_state)
   {
     RCLCPP_INFO(logger_, "Data type is 2D");
     this->data_module_ =
-        std::make_shared<RgbModule>(this->get_logger(), shared_from_this(), o3r_, this->port_info_.port, width, height);
+        std::make_shared<RgbModule>(this->get_logger(), shared_from_this(), o3r_, this->port_info_.port, width, height,
+                                    this->use_timestamp_from_device_);
     this->buffer_list_.insert(this->buffer_list_.end(),
                               std::get<std::shared_ptr<RgbModule>>(this->data_module_)->buffer_id_list_.begin(),
                               std::get<std::shared_ptr<RgbModule>>(this->data_module_)->buffer_id_list_.end());
@@ -143,7 +144,8 @@ TC_RETVAL CameraNode::on_configure(const rclcpp_lifecycle::State& prev_state)
   {
     RCLCPP_INFO(logger_, "Data type is 3D");
     this->data_module_ =
-        std::make_shared<TofModule>(this->get_logger(), shared_from_this(), o3r_, this->port_info_.port, width, height);
+        std::make_shared<TofModule>(this->get_logger(), shared_from_this(), o3r_, this->port_info_.port, width, height,
+                                    this->use_timestamp_from_device_);
     this->buffer_list_.insert(this->buffer_list_.end(),
                               std::get<std::shared_ptr<TofModule>>(this->data_module_)->buffer_id_list_.begin(),
                               std::get<std::shared_ptr<TofModule>>(this->data_module_)->buffer_id_list_.end());
@@ -376,6 +378,13 @@ void CameraNode::init_params()
   xmlrpc_port_descriptor.integer_range.push_back(xmlrpc_port_range);
   this->declare_parameter("xmlrpc_port", ifm3d::DEFAULT_XMLRPC_PORT, xmlrpc_port_descriptor);
 
+  rcl_interfaces::msg::ParameterDescriptor use_timestamp_from_device_descriptor;
+  use_timestamp_from_device_descriptor.name = "use_timestamp_from_device";
+  use_timestamp_from_device_descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  use_timestamp_from_device_descriptor.description =
+      "Uses timestamp from VPU for messages if true; uses ROS time if false; default is true";
+  this->declare_parameter("use_timestamp_from_device", true, use_timestamp_from_device_descriptor);
+
   // TODO: extend parameter description to include required params:
   // password: for lock / unlock of JSON configuration
 }
@@ -399,6 +408,9 @@ void CameraNode::parse_params()
 
   this->get_parameter("xmlrpc_port", this->xmlrpc_port_);
   RCLCPP_INFO(this->logger_, "xmlrpc_port: %u", this->xmlrpc_port_);
+
+  this->get_parameter("use_timestamp_from_device", this->use_timestamp_from_device_);
+  RCLCPP_INFO(this->logger_, "use_timestamp_from_device: %s", this->use_timestamp_from_device_ ? "true" : "false");
 }
 
 void CameraNode::set_parameter_event_callbacks()
@@ -431,6 +443,16 @@ void CameraNode::set_parameter_event_callbacks()
     RCLCPP_INFO(logger_, "New xmlrpc_port: %d", this->xmlrpc_port_);
   };
   registered_param_callbacks_["xmlrpc_port"] = param_subscriber_->add_parameter_callback("xmlrpc_port", xmlrpc_port_cb);
+
+  auto use_timestamp_from_device_cb = [this](const rclcpp::Parameter& p) {
+    this->use_timestamp_from_device_ = p.as_bool();
+    RCLCPP_WARN(logger_,
+                "This new timestamp behavior will be used after CONFIGURE transition was called: "
+                "use_timestamp_from_device=%s",
+                this->use_timestamp_from_device_ ? "true" : "false");
+  };
+  registered_param_callbacks_["use_timestamp_from_device"] =
+      param_subscriber_->add_parameter_callback("use_timestamp_from_device", use_timestamp_from_device_cb);
 }
 
 void CameraNode::frame_callback(ifm3d::Frame::Ptr frame)

--- a/src/lib/ods_module.cpp
+++ b/src/lib/ods_module.cpp
@@ -16,8 +16,12 @@
 
 namespace ifm3d_ros2
 {
-OdsModule::OdsModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr)
-  : FunctionModule(logger), node_ptr_(node_ptr), frame_id_("ifm_base_link")
+OdsModule::OdsModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr,
+                     bool use_timestamp_from_device)
+  : FunctionModule(logger)
+  , node_ptr_(node_ptr)
+  , frame_id_("ifm_base_link")
+  , use_timestamp_from_device_(use_timestamp_from_device)
 {
   RCLCPP_INFO(logger_, "OdsModule contructor called.");
 
@@ -78,7 +82,7 @@ ifm3d_ros2::msg::Zones OdsModule::extract_zones(ifm3d::Frame::Ptr frame)
   // Define the header
   zones_msg.header = std_msgs::msg::Header();
   zones_msg.header.frame_id = frame_id_;
-  zones_msg.header.stamp = rclcpp::Time(zones_data.timestamp_ns);
+  zones_msg.header.stamp = use_timestamp_from_device_ ? rclcpp::Time(zones_data.timestamp_ns) : node_ptr_->now();
 
   zones_msg.zone_config_id = zones_data.zone_config_id;
   zones_msg.zone_occupied = zones_data.zone_occupied;

--- a/src/lib/ods_node.cpp
+++ b/src/lib/ods_node.cpp
@@ -348,6 +348,13 @@ void OdsNode::init_params()  // TODO cleanup params
   xmlrpc_port_range.step = 1;
   xmlrpc_port_descriptor.integer_range.push_back(xmlrpc_port_range);
   this->declare_parameter("xmlrpc_port", ifm3d::DEFAULT_XMLRPC_PORT, xmlrpc_port_descriptor);
+
+  rcl_interfaces::msg::ParameterDescriptor use_timestamp_from_device_descriptor;
+  use_timestamp_from_device_descriptor.name = "use_timestamp_from_device";
+  use_timestamp_from_device_descriptor.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  use_timestamp_from_device_descriptor.description =
+      "Uses timestamp from VPU for messages if true; uses ROS time if false; default is true";
+  this->declare_parameter("use_timestamp_from_device", true, use_timestamp_from_device_descriptor);
 }
 
 void OdsNode::parse_params()
@@ -368,6 +375,9 @@ void OdsNode::parse_params()
 
   this->get_parameter("xmlrpc_port", this->xmlrpc_port_);
   RCLCPP_INFO(this->logger_, "xmlrpc_port: %u", this->xmlrpc_port_);
+
+  this->get_parameter("use_timestamp_from_device", this->use_timestamp_from_device_);
+  RCLCPP_INFO(this->logger_, "use_timestamp_from_device_: %s", this->use_timestamp_from_device_ ? "true" : "false");
 }
 
 void OdsNode::set_parameter_event_callbacks()
@@ -400,6 +410,16 @@ void OdsNode::set_parameter_event_callbacks()
     RCLCPP_INFO(logger_, "New xmlrpc_port: %d", this->xmlrpc_port_);
   };
   registered_param_callbacks_["xmlrpc_port"] = param_subscriber_->add_parameter_callback("xmlrpc_port", xmlrpc_port_cb);
+
+  auto use_timestamp_from_device_cb = [this](const rclcpp::Parameter& p) {
+    this->use_timestamp_from_device_ = p.as_bool();
+    RCLCPP_WARN(logger_,
+                "This new timestamp behavior will be used after CONFIGURE transition was called: "
+                "use_timestamp_from_device=%s",
+                this->use_timestamp_from_device_ ? "true" : "false");
+  };
+  registered_param_callbacks_["use_timestamp_from_device"] =
+      param_subscriber_->add_parameter_callback("use_timestamp_from_device", use_timestamp_from_device_cb);
 }
 
 void OdsNode::frame_callback(ifm3d::Frame::Ptr frame)

--- a/src/lib/rgb_module.cpp
+++ b/src/lib/rgb_module.cpp
@@ -16,8 +16,14 @@
 namespace ifm3d_ros2
 {
 RgbModule::RgbModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr,
-                     ifm3d::O3R::Ptr o3r_ptr, std::string port, uint32_t width, uint32_t height)
-  : FunctionModule(logger), node_ptr_(node_ptr), tf_publisher_(node_ptr, o3r_ptr, port), width_(width), height_(height)
+                     ifm3d::O3R::Ptr o3r_ptr, std::string port, uint32_t width, uint32_t height,
+                     bool use_timestamp_from_device)
+  : FunctionModule(logger)
+  , node_ptr_(node_ptr)
+  , tf_publisher_(node_ptr, o3r_ptr, port)
+  , width_(width)
+  , height_(height)
+  , use_timestamp_from_device_(use_timestamp_from_device)
 {
   RCLCPP_INFO(logger_, "RgbModule contructor called.");
 
@@ -80,7 +86,8 @@ void RgbModule::handle_frame(ifm3d::Frame::Ptr frame)
                    buffer_id_utils::vector_to_string(this->buffer_id_list_).c_str());
   RCLCPP_DEBUG(logger_, "Received new Frame.");
 
-  rclcpp::Time frame_ts = ifm3d_ros2::ifm3d_to_ros_time(frame->TimeStamps()[0]);
+  rclcpp::Time frame_ts =
+      use_timestamp_from_device_ ? ifm3d_ros2::ifm3d_to_ros_time(frame->TimeStamps()[0]) : this->node_ptr_->now();
   RCLCPP_DEBUG(logger_, "Frame timestamp: %f", frame_ts.seconds());
 
   auto optical_header = std_msgs::msg::Header();

--- a/src/lib/tof_module.cpp
+++ b/src/lib/tof_module.cpp
@@ -16,8 +16,14 @@
 namespace ifm3d_ros2
 {
 TofModule::TofModule(rclcpp::Logger logger, rclcpp_lifecycle::LifecycleNode::SharedPtr node_ptr,
-                     ifm3d::O3R::Ptr o3r_ptr, std::string port, uint32_t width, uint32_t height)
-  : FunctionModule(logger), node_ptr_(node_ptr), tf_publisher_(node_ptr, o3r_ptr, port), width_(width), height_(height)
+                     ifm3d::O3R::Ptr o3r_ptr, std::string port, uint32_t width, uint32_t height,
+                     bool use_timestamp_from_device)
+  : FunctionModule(logger)
+  , node_ptr_(node_ptr)
+  , tf_publisher_(node_ptr, o3r_ptr, port)
+  , width_(width)
+  , height_(height)
+  , use_timestamp_from_device_(use_timestamp_from_device)
 {
   RCLCPP_INFO(logger_, "TofModule contructor called.");
 
@@ -86,7 +92,8 @@ void TofModule::handle_frame(ifm3d::Frame::Ptr frame)
                    buffer_id_utils::vector_to_string(this->buffer_id_list_).c_str());
   RCLCPP_DEBUG(logger_, "Received new Frame.");
 
-  rclcpp::Time frame_ts = ifm3d_ros2::ifm3d_to_ros_time(frame->TimeStamps()[0]);
+  rclcpp::Time frame_ts =
+      use_timestamp_from_device_ ? ifm3d_ros2::ifm3d_to_ros_time(frame->TimeStamps()[0]) : this->node_ptr_->now();
   RCLCPP_DEBUG(logger_, "Frame timestamp: %f", frame_ts.seconds());
 
   auto cloud_header = std_msgs::msg::Header();


### PR DESCRIPTION
Hi,

I've added a parameter to the camera_node and ods_node to select a different time source for the message headers.
The default behavior mirrors the current behavior: the time received from the VPU is used to stamp messages.
If the new parameter `use_timestamp_from_device` is set to false, the ROS time is used for stamped messages instead.
This might be useful if NTP is not setup for the VPU.

I've added the parameter to both the camera_node and ods_node, but could only test the correct behavior for the camera_node.